### PR TITLE
Sending Events with MessageId and correlationId fields

### DIFF
--- a/iothub.class.nut
+++ b/iothub.class.nut
@@ -193,6 +193,12 @@ class iothub.HTTP {
             "Authorization": _config.sharedAccessSignature,
             "iothub-to": path
         };
+        if(message.getMessageId() != null) {
+            httpHeaders["iothub-messageId"] <- message.getMessageId();
+        }
+        if(message.getCorrelationId() != null) {
+            httpHeaders["iothub-correlationId"] <- message.getCorrelationId();
+        }
         foreach (k,v in message.getProperties()) {
             httpHeaders["IoTHub-app-" + k] <- v;
         }
@@ -415,6 +421,12 @@ class iothub.Message {
     
     function unsetProperty(key) {
         if (key in _properties) delete _properties[key];
+    }
+    function getMessageId() {
+	return messageId;
+    }
+    function getCorrelationId() {
+	return correlationId;
     }
 }
 

--- a/tests/Client.agent.test.nut
+++ b/tests/Client.agent.test.nut
@@ -122,6 +122,65 @@ class ClientTestCase extends ImpTestCase {
     }
 
     /**
+     * Test client::sendEvent() with Message Id
+     */
+    function test4SendEventwithMessageId() {
+        return Promise(function (resolve, reject) {
+            local message = { somevalue = "123" };
+            local headers = {
+              "IoTHub-MessageId": "id_" + math.rand()
+            }
+            this._client.sendEvent(iothub.Message(message,headers), function(err, res) {
+                if (err) {
+                    reject("sendEvent error: " + err.message + " (" + err.response.statuscode + ")");
+                } else {
+                    resolve("sendEvent successful");
+                }
+            });
+        }.bindenv(this));
+    }
+
+    /**
+     * Test client::sendEvent() with Correlation Id
+     */
+    function test5SendEventwithCorrelationId() {
+        return Promise(function (resolve, reject) {
+            local message = { somevalue = "123" };
+            local headers = {
+              "IoTHub-CorrelationId": "correlationid_" + math.rand()
+            }
+            this._client.sendEvent(iothub.Message(message,headers), function(err, res) {
+                if (err) {
+                    reject("sendEvent error: " + err.message + " (" + err.response.statuscode + ")");
+                } else {
+                    resolve("sendEvent successful");
+                }
+            });
+        }.bindenv(this));
+    }
+
+    /**
+     * Tests client::sendEvent() with message Id and correlation Id
+     */
+    function test6SendEventwithMessageIdCorrelationId() {
+        return Promise(function (resolve, reject) {
+            // gen unique test message
+            local message = { somevalue = "123" };
+            local headers = {
+              "IoTHub-MessageId": "messageid_" + math.rand(),
+              "IoTHub-CorrelationId": "correlationid_" + math.rand()
+            };
+            this._client.sendEvent(iothub.Message(message,headers), function(err, res) {
+                if (err) {
+                    reject("sendEvent error: " + err.message + " (" + err.response.statuscode + ")");
+                } else {
+                    resolve("sendEvent successful");
+                }
+            });
+        }.bindenv(this));
+    }
+
+    /**
      * Removes test device
      */
     function tearDown() {


### PR DESCRIPTION
Testing was done via using send commands and observing the fields in the event captured in IoTHub afterwards.

Tests were integrated in tests/Client.agent.test.nut

Test 1 - sending messageId results:
`
{
"somevalue": "123",
  "EventProcessedUtcTime": "2016-03-20T00:01:17.7951093Z",
  "PartitionId": 3,
  "EventEnqueuedUtcTime": "2016-03-20T00:01:17.904Z",
  "IoTHub": {
    "MessageId": "id_695580105",
    "CorrelationId": null,
    "ConnectionDeviceId": "device2145127372356724426",
    "ConnectionDeviceGenerationId": "635940288737195878",
    "EnqueuedTime": "0001-01-01T00:00:00",
    "StreamId": null
  }
}
`


Test 2 - sending correlationId results:
`
{
  "somevalue": "123",
  "EventProcessedUtcTime": "2016-03-20T00:01:18.0606896Z",
  "PartitionId": 3,
  "EventEnqueuedUtcTime": "2016-03-20T00:01:18.154Z",
  "IoTHub": {
    "MessageId": null,
    "CorrelationId": "correlationid_926756705",
    "ConnectionDeviceId": "device2145127372356724426",
    "ConnectionDeviceGenerationId": "635940288737195878",
    "EnqueuedTime": "0001-01-01T00:00:00",
    "StreamId": null
  }
}
`

Test 3 - sending messageId and correlationId results:
`
{
  "somevalue": "123",
  "EventProcessedUtcTime": "2016-03-20T00:01:18.3593219Z",
  "PartitionId": 3,
  "EventEnqueuedUtcTime": "2016-03-20T00:01:18.404Z",
  "IoTHub": {
    "MessageId": "messageid_753671132",
    "CorrelationId": "correlationid_565539803",
    "ConnectionDeviceId": "device2145127372356724426",
    "ConnectionDeviceGenerationId": "635940288737195878",
    "EnqueuedTime": "0001-01-01T00:00:00",
    "StreamId": null
  }
}
`