### PR TITLE
Allow async replies for Direct Methods and follow the "error-first" practice in callbacks

### DIFF
--- a/.impt.test
+++ b/.impt.test
@@ -1,5 +1,5 @@
 {
-  "deviceGroupId": "c2b77a7f-642e-0bf5-cd1e-f2fbe77fe9f3",
+  "deviceGroupId": "dfff2ad8-cf09-3fcc-87d4-299e030e27d4",
   "timeout": 90,
   "stopOnFail": false,
   "allowDisconnect": false,

--- a/AzureIoTHub.agent.lib.nut
+++ b/AzureIoTHub.agent.lib.nut
@@ -1240,7 +1240,6 @@ class AzureIoTHub {
         }
 
         function _handleDesPropsMsg(message, topic) {
-            // TODO: Check the EI's spec on message receiving
             message = message.tostring();
             local parsedMsg = null;
             try {
@@ -1254,7 +1253,6 @@ class AzureIoTHub {
         }
 
         function _handleTwinResponse(message, topic) {
-            // TODO: Check the EI's spec on message receiving
             message = message.tostring();
             local status = null;
             local reqId = null;
@@ -1324,7 +1322,6 @@ class AzureIoTHub {
         }
 
         function _handleDirMethodMsg(message, topic) {
-            // TODO: Check the EI's spec on message receiving
             message = message.tostring();
             local methodName = null;
             local reqId = null;

--- a/AzureIoTHub.agent.lib.nut
+++ b/AzureIoTHub.agent.lib.nut
@@ -646,6 +646,7 @@ class AzureIoTHub {
 
         _connStrParsed          = null;
         _options                = null;
+        _msgOptions             = null;
         _mqttclient             = null;
         _topics                 = null;
 
@@ -722,6 +723,10 @@ class AzureIoTHub {
             foreach (optName, optVal in options) {
                 _options[optName] <- optVal;
             }
+
+            _msgOptions = {
+                "qos" : _options.qos
+            };
 
             _initTopics(_connStrParsed.DeviceId);
         }
@@ -813,7 +818,7 @@ class AzureIoTHub {
             local topic = _topics.msgSend + props;
             local reqId = _reqNum++;
 
-            local mqttMsg = _mqttclient.createmessage(topic, msg.getBody(), _options.qos);
+            local mqttMsg = _mqttclient.createmessage(topic, msg.getBody(), _msgOptions);
 
             local msgSentCb = function (err) {
                 if (reqId in _msgPendingQueue) {
@@ -1000,7 +1005,7 @@ class AzureIoTHub {
             local topic = _topics.twinGet + "?$rid=" + reqId;
             _reqNum++;
 
-            local mqttMsg = _mqttclient.createmessage(topic, "", _options.qos);
+            local mqttMsg = _mqttclient.createmessage(topic, "", _msgOptions);
 
             local msgSentCb = function (err) {
                 if (_twinRetrievedCb != null) {
@@ -1069,7 +1074,7 @@ class AzureIoTHub {
                 onUpdated && onUpdated(props, AZURE_IOT_CLIENT_ERROR_GENERAL);
                 return;
             }
-            local mqttMsg = _mqttclient.createmessage(topic, jsonProps, _options.qos);
+            local mqttMsg = _mqttclient.createmessage(topic, jsonProps, _msgOptions);
 
             local msgSentCb = function (err) {
                 if (reqId in _twinPendingRequests) {
@@ -1345,7 +1350,7 @@ class AzureIoTHub {
                 _logError("Exception at parsing the response body for Direct Method: " + e);
                 return;
             }
-            local mqttMsg = _mqttclient.createmessage(topic, respJson, _options.qos);
+            local mqttMsg = _mqttclient.createmessage(topic, respJson, _msgOptions);
 
             local msgSentCb = function (err) {
                 if (err != 0) {

--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ The method returns nothing. A result of the sending may be obtained via the [*on
 It is allowed to send a new message while the previous send operation is not completed yet. 
 Maximum amount of pending operations is defined by the [client settings](#optional-settings).
 
+Due to limited support of the `retain` MQTT flag by Azure IoT Hub (described [here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#sending-device-to-cloud-messages)) this library doesn't currently support it.
+
 If *message* parameter is `null` or has incompatible type, the method will throw an exception.
 
 | Parameter | Data Type | Required? | Description |

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Only one instance of this class is allowed.
 - device twin operations (optional functionality)
 - direct methods processing (optional functionality)
 
+Please keep in mind [Azure IoT Hub limitations](https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/iot-hub-limits.md).
+
 All optional functionalities are disabled after a client instantiation. If an optional functionality is needed it should be enabled after the client is successfully connected. And it should be explicitly re-enabled after every re-connection of the client.
 The client provides individual methods to enable every optional feature.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ This method returns a new AzureIoTHub.Message instance.
 
 | Parameter | Data Type | Required? | Description |
 | --- | --- | --- | --- |
-| *message* | [Any supported by the MQTT API](TODO-link) TODO - update link | Yes | Message body. |
+| *message* | [Any supported by the MQTT API](https://developer.electricimp.com/api/mqtt/mqttclient/createmessage). | Yes | Message body. |
 | *props* | Table | Optional | Key-value table with the message properties. Every key is always a *String* with the name of the property. The value is the corresponding value of the property. Keys and values are fully application specific. |
 
 #### Example ####
@@ -221,7 +221,7 @@ This method returns a key-value table with the properties of the message. Every 
 
 ### getBody() ###
 
-This method returns the message's body. Messages that have been created locally will be of the same type as they were when created, but messages came from Azure IoT Hub are of one of the [types supported by the MQTT API](TODO-link) TODO - update link.
+This method returns the message's body. Messages that have been created locally will be of the same type as they were when created, but messages came from Azure IoT Hub are of one of the [types supported by the MQTT API](https://developer.electricimp.com/api/mqtt/mqttclient/onmessage).
 
 ## AzureIoTHub.DirectMethodResponse ##
 
@@ -294,6 +294,7 @@ These settings affect the client's behavior and the operations. Every setting is
 | Key (String) | Value Type | Default | Description |
 | --- | --- | --- | --- |
 | "qos" | Integer | 0 | MQTT QoS. Azure IoT Hub supports QoS `0` and `1` only. |
+| "keepAlive" | Integer | 60 | Keep-alive MQTT parameter, in seconds. For more information, see [here](https://developer.electricimp.com/api/mqtt/mqttclient/connect). |
 | "timeout" | Integer | 10 | Timeout (in seconds) for [Retrieve Twin](#retrievetwinpropertiesonretrieved) and [Update Twin](#updatetwinpropertiesprops-onupdated) operations. |
 | "maxPendingTwinRequests" | Integer | 3 | Maximum amount of pending [Update Twin](#updatetwinpropertiesprops-onupdated) operations. |
 | "maxPendingSendRequests" | Integer | 3 | Maximum amount of pending [Send Message](#sendmessagemessage-onsent) operations. |
@@ -633,8 +634,8 @@ An *Integer* error code which specifies a concrete error (if any) happened durin
 | Error Code | Description |
 | --- | --- |
 | 0 | No error. |
-| 1-99 | [Codes returned by the MQTT API](TODO-link) TODO - update link |
-| 100-999 | [Azure IoT Hub errors](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support). |
+| -99..-1 and 128 | [Codes returned by the MQTT API](https://developer.electricimp.com/api/mqtt) |
+| 100-999 except 128 | [Azure IoT Hub errors](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support). |
 | 1000 | The client is not connected. |
 | 1001 | The client is already connected. |
 | 1002 | The feature is not enabled. |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Azure IoT Hub 3.0.0 #
 
-Azure IoT Hub is an Electric Imp agent-side library for interfacing with Azure IoT Hub version “2016-11-14”. The library consists of the following classes:
+Azure IoT Hub is an Electric Imp agent-side library for interfacing with Azure IoT Hub API version "2016-11-14". Starting with version 3 the library integrates with Azure IoT Hub using the MQTT protocol (rather than AMQP previously) as there is certain functionality such as Device Twins and Direct Methods that IoT Hub only supports via MQTT.
+
+**Note:** The Azure IoT Hub MQTT integration is currently in public Beta. Before proceeding, please sign up for access to the Azure IoT Hub MQTT integration using [this link](https://connect.electricimp.com/azure-mqtt-integration-signup).
+
+The library consists of the following classes:
 
 - [AzureIoTHub.Registry](#azureiothubregistry) &mdash; Device management class, all requests use HTTP to connect to Azure IoT Hub.
   - [create()](#createdeviceinfo-callback) &mdash; Creates a a new device identity in Azure IoT Hub.
@@ -282,6 +286,10 @@ This is a right place to enable optional functionalities, if needed.
 This callback is called every time the device is disconnected.
 
 This is a good place to call the [connect()](#connect) method again, if it was an unexpected disconnection.
+
+Note: 
+
+IoT Hub expires authentication tokens (currently, the library is configured to request tokens with a 1 hour life). When the token expires the client connection disconnects and the `onDisconnected(*error*)` handler is called. To reconnect with a new token you can simply execute the connect flow again (call [connect()](#connect).
 
 | Parameter | Data Type | Description |
 | --- | --- | --- |

--- a/tests/DirectMethods.agent.test.nut
+++ b/tests/DirectMethods.agent.test.nut
@@ -107,7 +107,7 @@ class DirectMethodsTestCase extends ImpTestCase {
     }
 
     function _enableMethods() {
-        local onMethod = function (name, params) {};
+        local onMethod = function (name, params, reply) {};
         return Promise(function (resolve, reject) {
             _azureMqttClient.enableDirectMethods(onMethod, function (err) {
                 if (err != 0) {

--- a/tests/Messages.agent.test.nut
+++ b/tests/Messages.agent.test.nut
@@ -103,7 +103,7 @@ class MessagesTestCase extends ImpTestCase {
         msgBody.writestring("test blob message");
         local msg = AzureIoTHub.Message(msgBody, {"prop1" : "val1"});
         return Promise(function (resolve, reject) {
-            _azureMqttClient.sendMessage(msg, function (msg, err) {
+            _azureMqttClient.sendMessage(msg, function (err, msg) {
                 if (err != 0) {
                     return reject(err);
                 }
@@ -140,7 +140,7 @@ class MessagesTestCase extends ImpTestCase {
     function _sendMessage() {
         local msg = AzureIoTHub.Message("test message", {"prop1" : "val1"});
         return Promise(function (resolve, reject) {
-            _azureMqttClient.sendMessage(msg, function (msg, err) {
+            _azureMqttClient.sendMessage(msg, function (err, msg) {
                 if (err != 0) {
                     return reject(err);
                 }

--- a/tests/Twins.agent.test.nut
+++ b/tests/Twins.agent.test.nut
@@ -131,7 +131,7 @@ class TwinsTestCase extends ImpTestCase {
                 }
                 return Promise.resolve(0);
             }.bindenv(this));
-    }        
+    }
 
     function testDisableTwin() {
         return _disableTwin()
@@ -195,7 +195,7 @@ class TwinsTestCase extends ImpTestCase {
     function _updateTwin() {
         local props = {"testProp" : "testVal"};
         return Promise(function (resolve, reject) {
-            _azureMqttClient.updateTwinProperties(props, function (props, err) {
+            _azureMqttClient.updateTwinProperties(props, function (err, props) {
                 if (err != 0) {
                     return reject(err);
                 }


### PR DESCRIPTION
Please note that the documentation was not updated in this PR. This PR is intended to solve [this issue](https://github.com/electricimp/AzureIoTHub/issues/26) ASAP.
The docs and examples will be updated later.